### PR TITLE
[STEP-6] 콘서트 예약 시스템 ERD 및 MOCK API 작성

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,6 +44,15 @@ dependencies {
 	testImplementation("org.testcontainers:junit-jupiter")
 	testImplementation("org.testcontainers:mysql")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+	// Swagger
+	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0")
+
+	compileOnly("org.projectlombok:lombok")
+	annotationProcessor("org.projectlombok:lombok")
+	runtimeOnly("com.h2database:h2")
+
+
 }
 
 tasks.withType<Test> {

--- a/src/main/java/kr/hhplus/be/server/balance/domain/Balance.java
+++ b/src/main/java/kr/hhplus/be/server/balance/domain/Balance.java
@@ -1,0 +1,4 @@
+package kr.hhplus.be.server.balance.domain;
+
+public class Balance {
+}

--- a/src/main/java/kr/hhplus/be/server/balance/domain/BalanceHistory.java
+++ b/src/main/java/kr/hhplus/be/server/balance/domain/BalanceHistory.java
@@ -1,0 +1,4 @@
+package kr.hhplus.be.server.balance.domain;
+
+public class BalanceHistory {
+}

--- a/src/main/java/kr/hhplus/be/server/balance/presentation/balanceController.java
+++ b/src/main/java/kr/hhplus/be/server/balance/presentation/balanceController.java
@@ -1,0 +1,44 @@
+package kr.hhplus.be.server.balance.presentation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.hhplus.be.server.balance.presentation.dto.request.ChargeRequest;
+import kr.hhplus.be.server.balance.presentation.dto.response.BalanceResponse;
+import kr.hhplus.be.server.balance.presentation.dto.response.ChargeResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@RequestMapping("/api/balance")
+@Tag(name = "Balance API", description = "잔액 충전/조회 관련 API")
+public class balanceController {
+
+    @Operation(summary = "잔액 조회", description = "사용자의 현재 잔액을 조회합니다")
+    @GetMapping("/{userid}")
+    public ResponseEntity<BalanceResponse> getBalance(@PathVariable String userid,
+                                                      @Parameter(description = "대기열 토큰", required = true)
+                                                      @RequestHeader("Auth") String token) {
+        BalanceResponse response = BalanceResponse.builder()
+                .userId(1L)
+                .balance("1000")
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "잔액 충전", description = "사용자의 잔액을 충전합니다")
+    @PostMapping("/{userid}/charge")
+    public ResponseEntity<ChargeResponse> chargeBalance(@PathVariable String userid,
+                                                        @Parameter(description = "대기열 토큰", required = true)
+                                                        @RequestHeader("Auth") String token
+    ) {
+        ChargeResponse response = ChargeResponse.builder()
+                .message("잔액 충전이 완료되었습니다.")
+                .balance("2000")
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/balance/presentation/dto/request/ChargeRequest.java
+++ b/src/main/java/kr/hhplus/be/server/balance/presentation/dto/request/ChargeRequest.java
@@ -1,0 +1,14 @@
+package kr.hhplus.be.server.balance.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "충전 요청")
+public record ChargeRequest(
+        @Schema(description = "유저 아이디", example = "user123")
+        String userId,
+
+        @Schema(description = "충전 금액", example = "1000.0")
+        String amount
+) {}

--- a/src/main/java/kr/hhplus/be/server/balance/presentation/dto/response/BalanceResponse.java
+++ b/src/main/java/kr/hhplus/be/server/balance/presentation/dto/response/BalanceResponse.java
@@ -1,0 +1,12 @@
+package kr.hhplus.be.server.balance.presentation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "잔액 응답")
+public record BalanceResponse(
+        @Schema(description = "현재 잔액", example = "1000")
+        String balance,
+        long userId
+) {}

--- a/src/main/java/kr/hhplus/be/server/balance/presentation/dto/response/ChargeResponse.java
+++ b/src/main/java/kr/hhplus/be/server/balance/presentation/dto/response/ChargeResponse.java
@@ -1,0 +1,14 @@
+package kr.hhplus.be.server.balance.presentation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "충전 응답")
+public record ChargeResponse(
+        @Schema(description = "응답 메시지", example = "잔액 충전이 완료되었습니다.")
+        String message,
+
+        @Schema(description = "충전 후 잔액", example = "2000")
+        String balance
+) {}

--- a/src/main/java/kr/hhplus/be/server/concert/domain/Concert.java
+++ b/src/main/java/kr/hhplus/be/server/concert/domain/Concert.java
@@ -1,0 +1,4 @@
+package kr.hhplus.be.server.concert.domain;
+
+public class Concert {
+}

--- a/src/main/java/kr/hhplus/be/server/concert/domain/ConcertSchedule.java
+++ b/src/main/java/kr/hhplus/be/server/concert/domain/ConcertSchedule.java
@@ -1,0 +1,4 @@
+package kr.hhplus.be.server.concert.domain;
+
+public class ConcertSchedule {
+}

--- a/src/main/java/kr/hhplus/be/server/concert/presentation/ConcertController.java
+++ b/src/main/java/kr/hhplus/be/server/concert/presentation/ConcertController.java
@@ -1,0 +1,55 @@
+package kr.hhplus.be.server.concert.presentation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.hhplus.be.server.concert.presentation.dto.response.ConcertScheduleResponse;
+import kr.hhplus.be.server.concert.presentation.dto.response.ConcertSeatAvailableResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/concert")
+@Tag(name = "ConcertSchedule API", description = "콘서트 예약 가능 관련 API")
+public class ConcertController {
+
+    // 예약 가능 날짜 목록 조회
+    @Operation(summary = "예약 가능 날짜 조회", description = "예약 가능한 날짜을 조회합니다")
+    @GetMapping("/schedules")
+    public ResponseEntity<List<ConcertScheduleResponse>> getConcertSchedule(@PathVariable long userId,
+                                                                            @Parameter(description = "대기열 토큰", required = true)
+                                                                            @RequestHeader("Auth") String token) {
+
+        ConcertScheduleResponse concertSchedule1 = ConcertScheduleResponse.builder()
+                .scheduleId(1L)
+                .concertDate(LocalDateTime.now().plusDays(1))
+                .build();
+
+        ConcertScheduleResponse concertSchedule2 = ConcertScheduleResponse.builder()
+                .scheduleId(1L)
+                .concertDate(LocalDateTime.now().plusDays(3))
+                .build();
+
+        List<ConcertScheduleResponse> response = List.of(concertSchedule1, concertSchedule2);
+
+        return ResponseEntity.ok(response);
+    }
+
+    // 예약 가능 콘서트 좌석 목록 조회
+    @Operation(summary = "예약 가능 좌석 조회", description = "예약 가능한 좌석을 조회합니다")
+    @GetMapping("/seats")
+    public ResponseEntity<ConcertSeatAvailableResponse> getConcertScheduleSeat(@PathVariable long userId,
+                                                                               @Parameter(description = "대기열 토큰", required = true)
+                                                                               @RequestHeader("Auth") String token) {
+
+        ConcertSeatAvailableResponse response = ConcertSeatAvailableResponse.builder()
+                .date(LocalDateTime.now())
+                .availableSeats(List.of(1, 2, 3, 4, 5))
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/concert/presentation/ConcertController.java
+++ b/src/main/java/kr/hhplus/be/server/concert/presentation/ConcertController.java
@@ -40,7 +40,7 @@ public class ConcertController {
 
     // 예약 가능 콘서트 좌석 목록 조회
     @Operation(summary = "예약 가능 좌석 조회", description = "예약 가능한 좌석을 조회합니다")
-    @GetMapping("/seats")
+    @GetMapping("/{concertScheduleId}/seats")
     public ResponseEntity<ConcertSeatAvailableResponse> getConcertScheduleSeat(@PathVariable long userId,
                                                                                @Parameter(description = "대기열 토큰", required = true)
                                                                                @RequestHeader("Auth") String token) {

--- a/src/main/java/kr/hhplus/be/server/concert/presentation/dto/response/ConcertScheduleResponse.java
+++ b/src/main/java/kr/hhplus/be/server/concert/presentation/dto/response/ConcertScheduleResponse.java
@@ -1,0 +1,14 @@
+package kr.hhplus.be.server.concert.presentation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Schema(description = "예약 가능 날짜 요청")
+public record ConcertScheduleResponse(
+        long scheduleId,
+        LocalDateTime concertDate
+) {
+}

--- a/src/main/java/kr/hhplus/be/server/concert/presentation/dto/response/ConcertSeatAvailableResponse.java
+++ b/src/main/java/kr/hhplus/be/server/concert/presentation/dto/response/ConcertSeatAvailableResponse.java
@@ -1,0 +1,16 @@
+package kr.hhplus.be.server.concert.presentation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+@Schema(description = "예약 가능 좌석 요청")
+public record ConcertSeatAvailableResponse(
+        LocalDateTime date,
+        List<Integer> availableSeats
+) {
+
+}

--- a/src/main/java/kr/hhplus/be/server/config/swagger/SwaggerConfig.java
+++ b/src/main/java/kr/hhplus/be/server/config/swagger/SwaggerConfig.java
@@ -1,0 +1,21 @@
+package kr.hhplus.be.server.config.swagger;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        Info info = new Info()
+                .title("Concert Reservation API")
+                .version("v1.0")
+                .description("콘서트 예약 시스템 API 문서");
+
+        return new OpenAPI()
+                .info(info);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/payment/domain/Payment.java
+++ b/src/main/java/kr/hhplus/be/server/payment/domain/Payment.java
@@ -1,0 +1,4 @@
+package kr.hhplus.be.server.payment.domain;
+
+public class Payment {
+}

--- a/src/main/java/kr/hhplus/be/server/payment/presentation/PaymentController.java
+++ b/src/main/java/kr/hhplus/be/server/payment/presentation/PaymentController.java
@@ -1,0 +1,28 @@
+package kr.hhplus.be.server.payment.presentation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.hhplus.be.server.payment.presentation.dto.request.PaymentRequest;
+import kr.hhplus.be.server.payment.presentation.dto.response.PaymentResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/payment")
+@Tag(name = "Payment API", description = "콘서트 결제 관련 API")
+public class PaymentController {
+
+    @Operation(summary = "콘서트 좌석 결제", description = "콘서트 좌석을 결제합니다")
+    @PostMapping("/pay")
+    public ResponseEntity<PaymentResponse> createPayment(@RequestBody PaymentRequest request,
+                                                @Parameter(description = "대기열 토큰", required = true) @RequestHeader("Auth") String token) {
+
+        PaymentResponse response = PaymentResponse.builder()
+                .message("결제에 성공했습니다.")
+                .paymentId(1L)
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/payment/presentation/dto/request/PaymentRequest.java
+++ b/src/main/java/kr/hhplus/be/server/payment/presentation/dto/request/PaymentRequest.java
@@ -1,0 +1,9 @@
+package kr.hhplus.be.server.payment.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "결제 요청")
+public record PaymentRequest(
+        long reservationId
+) {
+}

--- a/src/main/java/kr/hhplus/be/server/payment/presentation/dto/response/PaymentResponse.java
+++ b/src/main/java/kr/hhplus/be/server/payment/presentation/dto/response/PaymentResponse.java
@@ -1,0 +1,14 @@
+package kr.hhplus.be.server.payment.presentation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "결제 응답")
+public record PaymentResponse(
+        @Schema(description = "응답 메시지", example = "결제에 성공했습니다.")
+        String message,
+        @Schema(description = "결제 ID", example = "1")
+        Long paymentId
+
+) {}

--- a/src/main/java/kr/hhplus/be/server/queueToken/domain/QueueTokenStatus.java
+++ b/src/main/java/kr/hhplus/be/server/queueToken/domain/QueueTokenStatus.java
@@ -1,0 +1,5 @@
+package kr.hhplus.be.server.queueToken.domain;
+
+public enum QueueTokenStatus {
+    WAITING, ACTIVE
+}

--- a/src/main/java/kr/hhplus/be/server/queueToken/domain/Token.java
+++ b/src/main/java/kr/hhplus/be/server/queueToken/domain/Token.java
@@ -1,0 +1,4 @@
+package kr.hhplus.be.server.queueToken.domain;
+
+public class Token {
+}

--- a/src/main/java/kr/hhplus/be/server/queueToken/presentation/QueueTokenController.java
+++ b/src/main/java/kr/hhplus/be/server/queueToken/presentation/QueueTokenController.java
@@ -1,0 +1,47 @@
+package kr.hhplus.be.server.queueToken.presentation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.hhplus.be.server.queueToken.domain.QueueTokenStatus;
+import kr.hhplus.be.server.queueToken.presentation.dto.response.QueueTokenResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+
+@RestController
+@RequestMapping("/api/queue")
+@Tag(name = "QueueToken API", description = "대기열 토큰 관련 API")
+public class QueueTokenController {
+
+    // 대기열 토큰을 발급한다.
+    @Operation(summary = "대기열 토큰 발급", description = "대기열 토큰을 발급합니다.")
+    @PostMapping("/token")
+    public ResponseEntity<QueueTokenResponse> issueToken(@PathVariable long userId) {
+
+        QueueTokenResponse response = QueueTokenResponse.builder()
+                .token("uuid")
+                .expiredAt(LocalDateTime.now().plusMinutes(5))
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+
+    // 대기열 정보를 조회한다.
+    @Operation(summary = "대기열 토큰 조회", description = "대기열 토큰을 조회합니다.")
+    @GetMapping("/token/{userId}")
+    public ResponseEntity<QueueTokenResponse> getQueueToken(@PathVariable long userId,
+                                                            @Parameter(description = "대기열 토큰", required = true) @RequestHeader("Auth") String token) {
+
+        QueueTokenResponse response = QueueTokenResponse.builder()
+                .token("uuid")
+                .status(QueueTokenStatus.WAITING)
+                .num(5)
+                .expiredAt(LocalDateTime.now().plusMinutes(5))
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/src/main/java/kr/hhplus/be/server/queueToken/presentation/dto/response/QueueTokenResponse.java
+++ b/src/main/java/kr/hhplus/be/server/queueToken/presentation/dto/response/QueueTokenResponse.java
@@ -1,0 +1,18 @@
+package kr.hhplus.be.server.queueToken.presentation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import kr.hhplus.be.server.queueToken.domain.QueueTokenStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Schema(description = "대기열 토큰 응답")
+public record QueueTokenResponse(
+        String token,
+        QueueTokenStatus status,
+        int num,
+        LocalDateTime expiredAt
+) {
+}

--- a/src/main/java/kr/hhplus/be/server/reservation/domain/Reservation.java
+++ b/src/main/java/kr/hhplus/be/server/reservation/domain/Reservation.java
@@ -1,0 +1,4 @@
+package kr.hhplus.be.server.reservation.domain;
+
+public class Reservation {
+}

--- a/src/main/java/kr/hhplus/be/server/reservation/presentation/ReservationController.java
+++ b/src/main/java/kr/hhplus/be/server/reservation/presentation/ReservationController.java
@@ -1,0 +1,30 @@
+package kr.hhplus.be.server.reservation.presentation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.hhplus.be.server.reservation.presentation.dto.request.ReservationRequest;
+import kr.hhplus.be.server.reservation.presentation.dto.response.ReservationResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/reservation")
+@Tag(name = "Reservation API", description = "콘서트 예약 관련 API")
+public class ReservationController {
+
+    // 콘서트 좌석 예약
+    @Operation(summary = "콘서트 좌석 예약", description = "콘서트 좌석 예약합니다.")
+    @PostMapping("/reserve")
+    public ResponseEntity<ReservationResponse> createReserve(@RequestBody ReservationRequest request,
+                                                @Parameter(description = "대기열 토큰", required = true)
+                                                @RequestHeader("Auth") String token) {
+
+        ReservationResponse response = ReservationResponse.builder()
+                .message("좌석 예약에 성공했습니다.")
+                .reservationId(1L)
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/reservation/presentation/dto/request/ReservationRequest.java
+++ b/src/main/java/kr/hhplus/be/server/reservation/presentation/dto/request/ReservationRequest.java
@@ -1,0 +1,13 @@
+package kr.hhplus.be.server.reservation.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "좌석 예약 요청")
+public record ReservationRequest(
+        long concertId,
+        LocalDateTime date,
+        int seatNum
+) {
+}

--- a/src/main/java/kr/hhplus/be/server/reservation/presentation/dto/response/ReservationResponse.java
+++ b/src/main/java/kr/hhplus/be/server/reservation/presentation/dto/response/ReservationResponse.java
@@ -1,0 +1,14 @@
+package kr.hhplus.be.server.reservation.presentation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "예약 응답")
+public record ReservationResponse(
+        @Schema(description = "응답 메시지", example = "좌석 예약에 성공했습니다.")
+        String message,
+
+        @Schema(description = "예약 ID", example = "1")
+        Long reservationId
+) {}

--- a/src/main/java/kr/hhplus/be/server/seat/domain/Seat.java
+++ b/src/main/java/kr/hhplus/be/server/seat/domain/Seat.java
@@ -1,0 +1,4 @@
+package kr.hhplus.be.server.seat.domain;
+
+public class Seat {
+}

--- a/src/main/java/kr/hhplus/be/server/user/domain/User.java
+++ b/src/main/java/kr/hhplus/be/server/user/domain/User.java
@@ -1,0 +1,4 @@
+package kr.hhplus.be.server.user.domain;
+
+public class User {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,20 +3,11 @@ spring:
     name: hhplus
   profiles:
     active: local
-  datasource:
-    name: HangHaePlusDataSource
-    type: com.zaxxer.hikari.HikariDataSource
-    hikari:
-      maximum-pool-size: 3
-      connection-timeout: 10000
-      max-lifetime: 60000
-    driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     open-in-view: false
-    generate-ddl: false
-    show-sql: false
+    show-sql: true
     hibernate:
-      ddl-auto: none
+      ddl-auto: create
     properties:
       hibernate.timezone.default_storage: NORMALIZE_UTC
       hibernate.jdbc.time_zone: UTC
@@ -24,8 +15,25 @@ spring:
 ---
 spring.config.activate.on-profile: local, test
 
+# H2 Database
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/hhplus?characterEncoding=UTF-8&serverTimezone=UTC
-    username: application
-    password: application
+    url: jdbc:h2:mem:test
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  h2:
+    console:
+      enabled: true  # H2 콘솔 활성화
+      path: /h2-console
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+    tags-sorter: alpha
+    operations-sorter: alpha
+  api-docs:
+    path: /api-docs
+  show-actuator: true
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json


### PR DESCRIPTION
## PR 설명
1. MOCK API를 작성 했습니다.
- swagger를 사용하여 API 명세를 작성했습니다.
### [API명세](https://github.com/Kimseonbeen/hhplus-concert/wiki/API-%EB%AA%85%EC%84%B8)

2. ERD를 작성 했습니다.
### [ERD](https://github.com/Kimseonbeen/hhplus-concert/wiki/ERD)

## 리뷰 포인트
도메인형 구조로 패키지를 설계하면서 아래와 같은 구조를 선택했는데, 이 설계가 적절한지 궁금합니다.

Concert 도메인: Concert와 ConcertSchedule을 포함
Balance 도메인: Balance와 BalanceHistory를 포함
이렇게 설계하던 중 좌석 예약 비즈니스를 구현할 때의 처리 방식에 대해 의문이 들었습니다.
좌석 예약은 SeatRepository와 ReservationRepository가 필요할 텐데, 이를 어떤 도메인에 배치해야 할지 고민입니다.

이전에 강의를 들었을 때, MSA 관점에서 서비스가 분리되어도 의존성 없이 독립적으로 동작해야 한다고 배웠습니다. 하지만 예약 도메인을 별도로 분리한다면, 좌석 예약 비즈니스가 제대로 작동하지 않을 것 같다는 생각이 듭니다.

이 점에 대해 조언을 듣고 싶습니다.