### PR TITLE
STEP[13/14] Redis 를 이용한 대기열 로직 이관

### DIFF
--- a/src/main/java/kr/hhplus/be/server/queueToken/domain/repository/QueueTokenRepository.java
+++ b/src/main/java/kr/hhplus/be/server/queueToken/domain/repository/QueueTokenRepository.java
@@ -8,12 +8,16 @@ import java.util.List;
 import java.util.Optional;
 
 public interface QueueTokenRepository {
-    long countByStatus(QueueTokenStatus status);
+    Long getWaitingTokenCount();
+    Long getActiveTokenCount();
     Optional<QueueToken> findByToken(String token);
-    QueueToken save(QueueToken queueToken);
-    long countByStatusAndIdLessThan(QueueTokenStatus status, long userId);
-    List<QueueToken> findByStatusAndExpiredAtBefore(QueueTokenStatus status, LocalDateTime dateTime);
-    Optional<QueueToken> findFirstByStatusOrderByIdAsc(QueueTokenStatus status);
-
+    void save(QueueToken queueToken);
+    Long countWaitingAhead(QueueTokenStatus status, long userId);
+    List<QueueToken> findExpiredTokens(QueueTokenStatus status, LocalDateTime dateTime);
+    Optional<QueueToken> getNextToken(QueueTokenStatus status);
     Optional<QueueToken> findByUserId(Long userId);
+    List<String> getWaitingTokens(Long needs);
+    void saveAcviveTokens(String s);
+    void removeWaitingTokens(List<String> waitingTokens);
+    void removeToken(String token);
 }

--- a/src/main/java/kr/hhplus/be/server/queueToken/domain/service/QueueTokenService.java
+++ b/src/main/java/kr/hhplus/be/server/queueToken/domain/service/QueueTokenService.java
@@ -20,7 +20,7 @@ import java.util.List;
 public class QueueTokenService {
 
     private final QueueTokenRepository queueTokenRepository;
-    private static final long MAX_ACTIVE_TOKEN_COUNT = 100;
+    private static final long MAX_ACTIVE_TOKEN_COUNT = 150;
 
     @Transactional
     public QueueToken issueQueueToken(long userId) {
@@ -62,6 +62,8 @@ public class QueueTokenService {
     public void expireToken(String token) {
         queueTokenRepository.removeToken(token);
     }
+
+
 
     // 대기 토큰 활성화
     public void activateNextWaitingToken() {

--- a/src/main/java/kr/hhplus/be/server/queueToken/infrastructure/QueueTokenJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/queueToken/infrastructure/QueueTokenJpaRepository.java
@@ -9,9 +9,9 @@ import java.util.List;
 import java.util.Optional;
 
 public interface QueueTokenJpaRepository extends JpaRepository<QueueToken, Long> {
-    long countByStatus(QueueTokenStatus status);
+    Long countByStatus(QueueTokenStatus status);
     Optional<QueueToken> findByToken(String token);
-    long countByStatusAndIdLessThan(QueueTokenStatus status, long userId);
+    Long countByStatusAndIdLessThan(QueueTokenStatus status, long userId);
     List<QueueToken> findByStatusAndExpiredAtBefore(QueueTokenStatus status, LocalDateTime dateTime);
     Optional<QueueToken> findFirstByStatusOrderByIdAsc(QueueTokenStatus status);
     Optional<QueueToken> findByUserId(Long userId);

--- a/src/main/java/kr/hhplus/be/server/queueToken/infrastructure/QueueTokenRedisRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/queueToken/infrastructure/QueueTokenRedisRepositoryImpl.java
@@ -1,0 +1,128 @@
+package kr.hhplus.be.server.queueToken.infrastructure;
+
+import kr.hhplus.be.server.queueToken.domain.model.QueueToken;
+import kr.hhplus.be.server.queueToken.domain.model.QueueTokenStatus;
+import kr.hhplus.be.server.queueToken.domain.repository.QueueTokenRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+@Repository
+@Primary
+@RequiredArgsConstructor
+@Slf4j
+public class QueueTokenRedisRepositoryImpl implements QueueTokenRepository {
+
+    private static final String WAITING_TOKEN_PREFIX = "waiting-token";
+    private static final String ACTIVE_TOKEN_PREFIX = "active-token";
+    private static final Duration TOKEN_TTL = Duration.ofMinutes(10);
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Override
+    public Long getWaitingTokenCount() {
+        return redisTemplate.opsForZSet().size(WAITING_TOKEN_PREFIX);
+    }
+
+    @Override
+    public Long getActiveTokenCount() {
+        Set<String> keys = redisTemplate.keys(ACTIVE_TOKEN_PREFIX + ":*");
+        return (long) keys.size();
+    }
+
+    @Override
+    public Optional<QueueToken> findByToken(String token) {
+
+        // 1. ACTIVE 상태 확인
+        String activeToken = redisTemplate.opsForValue().get(ACTIVE_TOKEN_PREFIX + ":" + token);
+
+        if (activeToken != null) {
+            return Optional.of(QueueToken.builder()
+                    .token(token)
+                    .position(0L)
+                    .status(QueueTokenStatus.ACTIVE)
+                    .build());
+        }
+
+        // 2. WAITING 상태 확인 및 대기 순서 조회
+        Double waitingScore = redisTemplate.opsForZSet().score(WAITING_TOKEN_PREFIX, token);
+
+        if (waitingScore != null) {
+            Long position = redisTemplate.opsForZSet().rank(WAITING_TOKEN_PREFIX, token);
+            return Optional.of(QueueToken.builder()
+                    .token(token)
+                    .status(QueueTokenStatus.WAITING)
+                    .position(position)
+                    .build());
+        }
+
+        // 3. 토큰을 찾지 못한 경우
+        return Optional.empty();
+    }
+
+    @Override
+    public void save(QueueToken queueToken) {
+        String token = queueToken.getToken();
+        if (queueToken.getStatus() == QueueTokenStatus.ACTIVE) {
+            redisTemplate.opsForValue().set(ACTIVE_TOKEN_PREFIX + ":" + token, token, TOKEN_TTL);
+        } else {
+            redisTemplate.opsForZSet().add(WAITING_TOKEN_PREFIX, token, System.currentTimeMillis());
+        }
+    }
+
+    @Override
+    public Long countWaitingAhead(QueueTokenStatus status, long userId) {
+        Long rank = redisTemplate.opsForZSet().rank(status.toString(), userId);
+        return rank != null ? rank : 0L;
+    }
+
+    @Override
+    public List<String> getWaitingTokens(Long needs) {
+        Set<String> tokens = redisTemplate.opsForZSet().range(WAITING_TOKEN_PREFIX, 0, needs);
+
+        if (tokens != null) return tokens.stream().toList();
+
+        return List.of();
+    }
+
+    @Override
+    public void removeWaitingTokens(List<String> tokens) {
+        redisTemplate.opsForZSet().remove(WAITING_TOKEN_PREFIX, tokens.toArray());
+    }
+
+    @Override
+    public void removeToken(String token) {
+        redisTemplate.delete(token);
+    }
+
+    @Override
+    public void saveAcviveTokens(String token) {
+        redisTemplate.opsForValue().set(ACTIVE_TOKEN_PREFIX + ":" + token, token);
+        redisTemplate.expire(ACTIVE_TOKEN_PREFIX + ":" + token, 10, TimeUnit.MINUTES);
+    }
+
+    // 처리 필요...
+    @Override
+    public List<QueueToken> findExpiredTokens(QueueTokenStatus status, LocalDateTime dateTime) {
+        return List.of();
+    }
+
+    @Override
+    public Optional<QueueToken> getNextToken(QueueTokenStatus status) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<QueueToken> findByUserId(Long userId) {
+        return Optional.empty();
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/queueToken/infrastructure/QueueTokenRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/queueToken/infrastructure/QueueTokenRepositoryImpl.java
@@ -17,8 +17,13 @@ public class QueueTokenRepositoryImpl implements QueueTokenRepository {
     private final QueueTokenJpaRepository queueTokenJpaRepository;
 
     @Override
-    public long countByStatus(QueueTokenStatus status) {
-        return queueTokenJpaRepository.countByStatus(status);
+    public Long getWaitingTokenCount() {
+        return queueTokenJpaRepository.countByStatus(QueueTokenStatus.WAITING);
+    }
+
+    @Override
+    public Long getActiveTokenCount() {
+        return queueTokenJpaRepository.countByStatus(QueueTokenStatus.ACTIVE);
     }
 
     @Override
@@ -27,27 +32,47 @@ public class QueueTokenRepositoryImpl implements QueueTokenRepository {
     }
 
     @Override
-    public QueueToken save(QueueToken queueToken) {
-        return queueTokenJpaRepository.save(queueToken);
+    public void save(QueueToken queueToken) {
+        queueTokenJpaRepository.save(queueToken);
     }
 
     @Override
-    public long countByStatusAndIdLessThan(QueueTokenStatus status, long userId) {
+    public Long countWaitingAhead(QueueTokenStatus status, long userId) {
         return queueTokenJpaRepository.countByStatusAndIdLessThan(status, userId);
     }
 
     @Override
-    public List<QueueToken> findByStatusAndExpiredAtBefore(QueueTokenStatus status, LocalDateTime dateTime) {
+    public List<QueueToken> findExpiredTokens(QueueTokenStatus status, LocalDateTime dateTime) {
         return queueTokenJpaRepository.findByStatusAndExpiredAtBefore(status, dateTime);
     }
 
     @Override
-    public Optional<QueueToken> findFirstByStatusOrderByIdAsc(QueueTokenStatus status) {
+    public Optional<QueueToken> getNextToken(QueueTokenStatus status) {
         return queueTokenJpaRepository.findFirstByStatusOrderByIdAsc(status);
     }
 
     @Override
     public Optional<QueueToken> findByUserId(Long userId) {
         return queueTokenJpaRepository.findByUserId(userId);
+    }
+
+    @Override
+    public List<String> getWaitingTokens(Long needs) {
+        return List.of();
+    }
+
+    @Override
+    public void saveAcviveTokens(String s) {
+
+    }
+
+    @Override
+    public void removeWaitingTokens(List<String> waitingTokens) {
+
+    }
+
+    @Override
+    public void removeToken(String token) {
+
     }
 }

--- a/src/main/java/kr/hhplus/be/server/queueToken/presentation/dto/response/QueueTokenResponse.java
+++ b/src/main/java/kr/hhplus/be/server/queueToken/presentation/dto/response/QueueTokenResponse.java
@@ -24,11 +24,11 @@ public record QueueTokenResponse(
                 .build();
    }
 
-    public static QueueTokenResponse of(QueueToken queueToken, long waitingNum) {
+    public static QueueTokenResponse of(QueueToken queueToken) {
         return QueueTokenResponse.builder()
                 .token(queueToken.getToken())
                 .status(queueToken.getStatus())
-                .num(waitingNum)
+                .num(queueToken.getPosition())
                 .expiredAt(queueToken.getExpiredAt())
                 .build();
     }

--- a/src/main/java/kr/hhplus/be/server/queueToken/presentation/scheduler/QueueTokenScheduler.java
+++ b/src/main/java/kr/hhplus/be/server/queueToken/presentation/scheduler/QueueTokenScheduler.java
@@ -16,23 +16,12 @@ public class QueueTokenScheduler {
 
     private final QueueTokenService queueTokenService;
 
-    //@Scheduled(fixedDelay = 1000)
+    @Scheduled(fixedDelay = 60000)
     public void QueueTokenStatusChange() {
         log.info("start schedule");
 
         try {
-            // 1. 만료된 ACTIVE 토큰 찾아서 EXPIRED로 변경
-            List<QueueToken> expiredTokens = queueTokenService.findExpiredActiveTokens();
-
-            for (QueueToken expiredToken : expiredTokens) {
-                log.info("Expired token processing - Token: {}", expiredToken.getToken());
-
-                // 2. 토큰 만료 처리
-                queueTokenService.expireToken(expiredToken.getUserId());
-
-                // 3. 다음 WAITING 토큰을 ACTIVE로 변경
-                queueTokenService.activateNextWaitingToken();
-            }
+            queueTokenService.activateNextWaitingToken();
         } catch (Exception e) {
             log.error("대기열 토큰 상태 변경 중 오류 발생", e);
         }

--- a/src/main/java/kr/hhplus/be/server/queueToken/presentation/scheduler/QueueTokenScheduler.java
+++ b/src/main/java/kr/hhplus/be/server/queueToken/presentation/scheduler/QueueTokenScheduler.java
@@ -16,7 +16,9 @@ public class QueueTokenScheduler {
 
     private final QueueTokenService queueTokenService;
 
-    @Scheduled(fixedDelay = 60000)
+    private static final int ACTIVATION_INTERVAL = 30;
+
+    @Scheduled(fixedDelay = ACTIVATION_INTERVAL * 1000)
     public void QueueTokenStatusChange() {
         log.info("start schedule");
 

--- a/src/main/java/kr/hhplus/be/server/reservation/application/ReservationFacade.java
+++ b/src/main/java/kr/hhplus/be/server/reservation/application/ReservationFacade.java
@@ -56,7 +56,9 @@ public class ReservationFacade {
         );
 
         // 토큰 만료 처리
-        queueTokenService.expireToken(command.userId());
+        queueTokenService.expireToken(command.token());
+
+        // 결재 완료 후, 해당 콘서트 스케쥴이 매진이라면, 상태 값을 변경
 
         return PaymentResult.from(payment);
     }


### PR DESCRIPTION
## PR 설명
STEP 13 : [링크](https://github.com/Kimseonbeen/hhplus-concert/wiki/%EC%A3%BC%EC%9A%94-%EC%BA%90%EC%8B%9C-%EC%A0%84%EB%9E%B5-%EB%B0%8F-Redis-%EB%A5%BC-%EC%9D%B4%EC%9A%A9%ED%95%9C-%EB%8C%80%EA%B8%B0%EC%97%B4-%EB%A1%9C%EC%A7%81-%EC%9D%B4%EA%B4%80-%EB%B3%B4%EA%B3%A0%EC%84%9C)

## 리뷰 포인트
- 대기열 로직을 DB에서 Redis로 변경하는 과정에서 DIP를 지키고자 했으나, 기존 도메인 대기열 레포지토리를 상당히 수정하게 되었습니다.
기존 QueueTokenRepositoryImpl는 삭제 하지 않고
QueueTokenRedisRepositoryImpl을 새로 생성하여 사용했는데, 다음과 같은 문제점이 발생했습니다.
기존 JPA 기반 메서드 네이밍을 보다 일반적인 방식으로 수정해야 했습니다.
Redis 도입 과정에서 도메인 레포지토리에 새로운 메서드를 추가해야 했습니다.
Redis 전용 메서드를 도메인 레포지토리에 추가하면서, 의도치 않게 기존 QueueTokenRepositoryImpl에도 새로운 메서드가 추가되는 문제가 발생했습니다.
이로 인해 변경이 쉽게 이루어지지 못했으며, 인터페이스가 제대로 정의되지 않은 것이 근본적인 원인인 것 같습니다. 하지만 이를 어떻게 개선해야 할지 감이 잘 오지 않습니다. 혹시 이런 부분에 피드백을 주실 수 있으실까요 ?  

- 대기열을 레디스로 변경을
활성화 토큰 :  Redis String
대기 토큰 : Redis Sorted Set을 사용했는데 적절한지 피드백 주시면 감사하겠습니다 !
---