### PR TITLE
feat: 아웃박스 스케줄러 분산 락 적용

### DIFF
--- a/src/main/java/kr/hhplus/be/server/common/outbox/OutboxEventScheduler.java
+++ b/src/main/java/kr/hhplus/be/server/common/outbox/OutboxEventScheduler.java
@@ -4,6 +4,8 @@ import kr.hhplus.be.server.common.serializer.DataSerializer;
 import kr.hhplus.be.server.reservation.infrastructure.client.DataPlatformClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,21 +19,37 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class OutboxEventScheduler {
 
+    private static final String OUTBOX_SCHEDULER_LOCK = "LOCK:outbox-scheduler";
+
     private final OutboxEventRepository outboxEventRepository;
     private final DataPlatformClient dataPlatformClient;
+    private final RedissonClient redissonClient;
 
     @Scheduled(fixedDelay = 10 * 1000) // 10초마다
     @Transactional
     public void processOutboxEvents() {
-        List<OutboxEvent> pendingEvents = outboxEventRepository.findAllByStatus(OutboxStatus.PENDING);
+        RLock lock = redissonClient.getLock(OUTBOX_SCHEDULER_LOCK);
 
-        for (OutboxEvent event : pendingEvents) {
-            try {
-                process(event);
-                event.publish();
-            } catch (Exception e) {
-                log.error("아웃박스 이벤트 처리 실패: id={}, type={}", event.getId(), event.getEventType(), e);
-                event.fail(e.getMessage());
+        if (!lock.tryLock()) {
+            log.info("다른 서버에서 아웃박스 처리 중, 스킵");
+            return;
+        }
+
+        try {
+            List<OutboxEvent> pendingEvents = outboxEventRepository.findAllByStatus(OutboxStatus.PENDING);
+
+            for (OutboxEvent event : pendingEvents) {
+                try {
+                    process(event);
+                    event.publish();
+                } catch (Exception e) {
+                    log.error("아웃박스 이벤트 처리 실패: id={}, type={}", event.getId(), event.getEventType(), e);
+                    event.fail(e.getMessage());
+                }
+            }
+        } finally {
+            if (lock.isHeldByCurrentThread()) {
+                lock.unlock();
             }
         }
     }


### PR DESCRIPTION
## Summary
- 다중 서버 환경에서 `OutboxEventScheduler`가 중복 실행되는 문제 해결
- Redisson 분산 락으로 한 서버만 실행, 나머지는 조용히 스킵
- 기존 `@DistributedLock` AOP는 락 실패 시 예외를 던져 스케줄러에 부적합하므로 Redisson 직접 사용

## Test plan
- [ ] 빌드 확인 (`./gradlew build -x test`)
- [ ] 단일 서버 환경에서 정상 실행 확인
- [ ] 다중 서버 환경에서 중복 실행 안 되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)