### PR TITLE
chore: EC2 배포 스텝 continue-on-error 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,7 @@ jobs:
     steps:
       - name: EC2 배포
         uses: appleboy/ssh-action@master
+        continue-on-error: true
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}


### PR DESCRIPTION
## Summary
- AWS 서버 중지 기간 동안 배포 실패로 워크플로우가 깨지는 것 방지
- `continue-on-error: true` 추가

> 서버 재가동 시 해당 옵션 제거 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)