### PR TITLE
docs: 응답 DTO Swagger @Schema 예시값 추가

### DIFF
--- a/src/main/java/kr/hhplus/be/server/balance/presentation/dto/response/BalanceResponse.java
+++ b/src/main/java/kr/hhplus/be/server/balance/presentation/dto/response/BalanceResponse.java
@@ -7,7 +7,9 @@ import lombok.Builder;
 @Builder
 @Schema(description = "잔액 응답")
 public record BalanceResponse(
+        @Schema(description = "유저 ID", example = "1")
         Long userId,
+        @Schema(description = "현재 잔액", example = "10000")
         Long amount
 ) {
         public static BalanceResponse from(Balance balance) {

--- a/src/main/java/kr/hhplus/be/server/concert/presentation/dto/response/ConcertScheduleResponse.java
+++ b/src/main/java/kr/hhplus/be/server/concert/presentation/dto/response/ConcertScheduleResponse.java
@@ -7,9 +7,11 @@ import lombok.Builder;
 import java.time.LocalDateTime;
 
 @Builder
-@Schema(description = "예약 가능 날짜 요청")
+@Schema(description = "예약 가능 날짜 응답")
 public record ConcertScheduleResponse(
+        @Schema(description = "콘서트 스케줄 ID", example = "1")
         Long concertScheduleId,
+        @Schema(description = "콘서트 날짜", example = "2026-06-01T18:00:00")
         LocalDateTime concertDate
 ) {
 

--- a/src/main/java/kr/hhplus/be/server/concert/presentation/dto/response/ConcertSeatAvailableResponse.java
+++ b/src/main/java/kr/hhplus/be/server/concert/presentation/dto/response/ConcertSeatAvailableResponse.java
@@ -8,9 +8,11 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Builder
-@Schema(description = "예약 가능 좌석 요청")
+@Schema(description = "예약 가능 좌석 응답")
 public record ConcertSeatAvailableResponse(
+        @Schema(description = "콘서트 날짜", example = "2026-06-01T18:00:00")
         LocalDateTime date,
+        @Schema(description = "예약 가능한 좌석 번호 목록", example = "[1, 2, 3, 4, 5]")
         List<Integer> availableSeats
 ) {
 

--- a/src/main/java/kr/hhplus/be/server/concert/presentation/dto/response/SeatResponse.java
+++ b/src/main/java/kr/hhplus/be/server/concert/presentation/dto/response/SeatResponse.java
@@ -1,11 +1,16 @@
 package kr.hhplus.be.server.concert.presentation.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
+@Schema(description = "좌석 응답")
 public record SeatResponse(
+        @Schema(description = "좌석 ID", example = "1")
         Long seatId,
+        @Schema(description = "좌석 번호", example = "15")
         Long seatNo,
+        @Schema(description = "좌석 가격", example = "50000")
         Long seatPrice
 ) {
 

--- a/src/main/java/kr/hhplus/be/server/queueToken/presentation/dto/response/QueueTokenResponse.java
+++ b/src/main/java/kr/hhplus/be/server/queueToken/presentation/dto/response/QueueTokenResponse.java
@@ -9,9 +9,13 @@ import java.time.LocalDateTime;
 @Builder
 @Schema(description = "대기열 토큰 응답")
 public record QueueTokenResponse(
+        @Schema(description = "대기열 토큰", example = "uuid-1234-abcd")
         String token,
+        @Schema(description = "토큰 상태 (WAITING/ACTIVE)", example = "WAITING")
         QueueTokenStatus status,
+        @Schema(description = "대기 순번", example = "5")
         Long num,
+        @Schema(description = "토큰 만료 시간", example = "2026-06-01T18:10:00")
         LocalDateTime expiredAt
 ) {
 
@@ -23,6 +27,4 @@ public record QueueTokenResponse(
                 .expiredAt(queueToken.getExpiredAt())
                 .build();
     }
-
-
 }

--- a/src/main/java/kr/hhplus/be/server/reservation/presentation/dto/response/PaymentResponse.java
+++ b/src/main/java/kr/hhplus/be/server/reservation/presentation/dto/response/PaymentResponse.java
@@ -7,9 +7,13 @@ import lombok.Builder;
 @Builder
 @Schema(description = "결제 응답")
 public record PaymentResponse(
+        @Schema(description = "결제 ID", example = "1")
         Long paymentId,
+        @Schema(description = "유저 ID", example = "1")
         Long userId,
+        @Schema(description = "예약 ID", example = "1")
         Long reservationId,
+        @Schema(description = "결제 금액", example = "50000")
         Long amount
 
 ) {

--- a/src/main/java/kr/hhplus/be/server/reservation/presentation/dto/response/ReservationResponse.java
+++ b/src/main/java/kr/hhplus/be/server/reservation/presentation/dto/response/ReservationResponse.java
@@ -11,11 +11,17 @@ import java.time.LocalDateTime;
 @Builder
 @Schema(description = "예약 응답")
 public record ReservationResponse(
+        @Schema(description = "예약 ID", example = "1")
         Long reservationId,
+        @Schema(description = "콘서트 ID", example = "1")
         Long concertId,
+        @Schema(description = "콘서트 일시", example = "2026-06-01T18:00:00")
         LocalDateTime concertAt,
+        @Schema(description = "좌석 정보")
         SeatResponse seat,
+        @Schema(description = "예약 상태 (PENDING/CONFIRMED/CANCELLED)", example = "PENDING")
         ReservationStatus reservationStatus,
+        @Schema(description = "예약 만료 시간", example = "2026-06-01T18:05:00")
         LocalDateTime expiredAt
 ) {
         public static ReservationResponse from(ReservationResult reservation) {


### PR DESCRIPTION
## Summary
- 모든 Response DTO 필드에 `@Schema(example = "...")` 추가
- Swagger UI에서 API 호출 시 예시값이 자동으로 표시됨
- 대상: `BalanceResponse`, `ConcertScheduleResponse`, `ConcertSeatAvailableResponse`, `SeatResponse`, `QueueTokenResponse`, `PaymentResponse`, `ReservationResponse`

## Test plan
- [ ] `/v3/api-docs` 정상 응답 확인
- [ ] Swagger UI에서 각 DTO 필드에 예시값 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)